### PR TITLE
Added pypy3 shebang and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Minimal Docker image for MAPLE v0.3.1 using Ubuntu base
+FROM ubuntu:20.04
+
+# install MAPLE
+RUN apt-get update && apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y unzip wget zip && \
+
+    # install pypy
+    wget -qO- "https://downloads.python.org/pypy/pypy3.9-v7.3.11-linux64.tar.bz2" | tar -xj && \
+    mv pypy*/bin/* /usr/local/bin/ && \
+    mv pypy*/include/* /usr/local/include/ && \
+    mv pypy*/lib/* /usr/local/lib/ && \
+    rm -rf pypy* && \
+
+    # install MAPLE
+    wget -q "https://github.com/NicolaDM/MAPLE/archive/refs/heads/main.zip" && \
+    unzip main.zip && \
+    rm main.zip && \
+    mv MAPLE-main /usr/local/bin/MAPLE && \
+    sed -i '1s/^/#! \/usr\/bin\/env pypy3\n/' /usr/local/bin/MAPLE/MAPLEv*.py && \
+    chmod a+x /usr/local/bin/MAPLE/MAPLEv*.py && \
+    ln -s /usr/local/bin/MAPLE/MAPLEv*.py /usr/local/bin/MAPLE.py && \
+
+    # clean up
+    rm -rf /root/.cache /tmp/*

--- a/MAPLEv0.3.1.py
+++ b/MAPLEv0.3.1.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env pypy3
 import sys
 from math import log
 import argparse


### PR DESCRIPTION
I added a shebang to the `MAPLEv*.py` script to be able to make it executable and use `pypy3` by default. I also added a `Dockerfile` to aid in building Docker images, such as this one:

https://hub.docker.com/r/niemasd/maple